### PR TITLE
feat: support all types loading into spark [ci]

### DIFF
--- a/SparkTest.NET.Tests/DataFrameExtensionTests.cs
+++ b/SparkTest.NET.Tests/DataFrameExtensionTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BunsenBurner;
+using BunsenBurner.Utility;
+using BunsenBurner.Verify.Xunit;
+using FluentAssertions;
+using SparkTest.NET.Extensions;
+using VerifyXunit;
+using Xunit;
+using static SparkTest.NET.Tests.Shared;
+
+namespace SparkTest.NET.Tests
+{
+    [UsesVerify]
+    public static class DataFrameExtensionTests
+    {
+        [Fact(DisplayName = "A data frame can be created from JSON data")]
+        public static async Task Case1() =>
+            await ArrangeUsingSpark(
+                    s =>
+                        s.CreateDataFrameFromData(
+                            new { Id = 1 },
+                            Enumerable.Range(2, 9).Select(i => new { Id = i }).ToArray()
+                        )
+                )
+                .Act(df => df.Debug())
+                .AssertResultIsUnchanged();
+
+        [Fact(DisplayName = "All primitive C# types can be loaded into spark")]
+        public static async Task Case2() =>
+            await ArrangeUsingSpark(
+                    s =>
+                        s.CreateDataFrameFromData(
+                            new
+                            {
+                                Byte = (byte)1,
+                                Short = (short)1,
+                                Int = 1,
+                                Long = 1L,
+                                Float = 1.0F,
+                                Double = 1.0,
+                                Decimal = (decimal)1.0,
+                                String = "a",
+                                Char = 'a',
+                                Bool = true,
+                                Date = DateTime.MinValue,
+                                DateTimeOffset = DateTimeOffset.MinValue,
+                                Binary = new byte[] { 1 }
+                            },
+                            new
+                            {
+                                Byte = (byte)2,
+                                Short = (short)2,
+                                Int = 2,
+                                Long = 2L,
+                                Float = 2.0F,
+                                Double = 2.0,
+                                Decimal = (decimal)2.0,
+                                String = "b",
+                                Char = 'b',
+                                Bool = false,
+                                Date = DateTime.MaxValue,
+                                DateTimeOffset = DateTimeOffset.MaxValue,
+                                Binary = new byte[] { 1 }
+                            }
+                        )
+                )
+                .Act(df => df.Debug())
+                .AssertResultIsUnchanged();
+
+        [Fact(DisplayName = "Array columns can be loaded into spark")]
+        public static async Task Case3() =>
+            await ArrangeUsingSpark(
+                    s =>
+                        s.CreateDataFrameFromData(
+                            new { Array = new[] { 1, 2, 3 } },
+                            new { Array = new[] { 4, 5, 6 } }
+                        )
+                )
+                .Act(df => df.Debug())
+                .AssertResultIsUnchanged();
+
+        [Fact(DisplayName = "Map/Dictionary columns can be loaded into spark")]
+        public static async Task Case4() =>
+            await ArrangeUsingSpark(
+                    s =>
+                        s.CreateDataFrameFromData(
+                            new
+                            {
+                                Map = new Dictionary<string, int>
+                                {
+                                    ["A"] = 1,
+                                    ["B"] = 2,
+                                    ["C"] = 3
+                                }
+                            },
+                            new
+                            {
+                                Map = new Dictionary<string, int>
+                                {
+                                    ["D"] = 4,
+                                    ["E"] = 5,
+                                    ["F"] = 6
+                                }
+                            }
+                        )
+                )
+                .Act(df => df.Debug())
+                .AssertResultIsUnchanged();
+
+        [Fact(DisplayName = "An empty enumerable will throw")]
+        public static async Task Case5() =>
+            await ArrangeUsingSpark(ManualDisposal.New)
+                .Act(s => s.Value.CreateDataFrameFromData(Enumerable.Empty<object>()))
+                .AssertFailsWith(
+                    (InvalidOperationException e) =>
+                        e.Message.Should().Be("Enumerable must not be empty")
+                );
+
+        [Fact(DisplayName = "Custom record columns can be loaded into spark")]
+        public static async Task Case6() =>
+            await ArrangeUsingSpark(
+                    s =>
+                        s.CreateDataFrameFromData(
+                            new
+                            {
+                                CreatedDate = DateTimeOffset.MinValue,
+                                Person = new
+                                {
+                                    Name = "Billy",
+                                    Age = 12,
+                                    Interests = new[]
+                                    {
+                                        new { Priority = 1, Name = "Football" },
+                                        new { Priority = 3, Name = "Cars" }
+                                    }
+                                }
+                            },
+                            new
+                            {
+                                CreatedDate = DateTimeOffset.MinValue,
+                                Person = new
+                                {
+                                    Name = "James",
+                                    Age = 11,
+                                    Interests = new[]
+                                    {
+                                        new { Priority = 1, Name = "Video Games" },
+                                        new { Priority = 2, Name = "TV" }
+                                    }
+                                }
+                            }
+                        )
+                )
+                .Act(df => df.Debug())
+                .AssertResultIsUnchanged();
+    }
+}

--- a/SparkTest.NET.Tests/Shared.cs
+++ b/SparkTest.NET.Tests/Shared.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using BunsenBurner;
+using Microsoft.Spark.Sql;
+using static SparkTest.NET.SparkSessionFactory;
+using Scenario = BunsenBurner.Scenario<BunsenBurner.Syntax.Aaa>;
+
+namespace SparkTest.NET.Tests
+{
+    internal static class Shared
+    {
+        internal static Scenario.Arranged<T> ArrangeUsingSpark<T>(Func<SparkSession, T> arrange) =>
+            UseSession(arrange).ArrangeData();
+    }
+}

--- a/SparkTest.NET.Tests/SparkSessionFactoryTests.cs
+++ b/SparkTest.NET.Tests/SparkSessionFactoryTests.cs
@@ -4,22 +4,17 @@ using System.Threading.Tasks;
 using BunsenBurner;
 using BunsenBurner.Verify.Xunit;
 using FluentAssertions;
-using Microsoft.Spark.Sql;
 using Microsoft.Spark.Sql.Types;
 using SparkTest.NET.Extensions;
 using VerifyXunit;
 using Xunit;
-using static SparkTest.NET.SparkSessionFactory;
-using Scenario = BunsenBurner.Scenario<BunsenBurner.Syntax.Aaa>;
+using static SparkTest.NET.Tests.Shared;
 
 namespace SparkTest.NET.Tests
 {
     [UsesVerify]
     public static class SparkSessionFactoryTests
     {
-        private static Scenario.Arranged<T> ArrangeUsingSpark<T>(Func<SparkSession, T> arrange) =>
-            UseSession(arrange).ArrangeData();
-
         [Fact(DisplayName = "A spark session can be returned and used to query")]
         public static async Task Case1() =>
             await ArrangeUsingSpark(
@@ -83,35 +78,21 @@ namespace SparkTest.NET.Tests
                 }
             }
                 .ArrangeData()
-                .Act(data => data.AsStructType(false).Json)
+                .Act(data => data.AsStructType().Json)
                 .AssertResultIsUnchanged();
-
-        [Fact(DisplayName = "Objects that cannot be serialized from .NET to Java throw")]
-        public static async Task Case5() =>
-            await new { Guid = Guid.NewGuid() }
-                .ArrangeData()
-                .Act(data => data.AsStructType(true))
-                .AssertFailsWith(
-                    (NotSupportedException e) =>
-                        e.Message
-                            .Should()
-                            .Be(
-                                "System.Guid is not supported in Spark or cannot be serialized from .NET to Java at this time"
-                            )
-                );
 
         [Fact(DisplayName = "Nullable objects are supported")]
         public static async Task Case6() =>
             await new { NullableInt = (int?)null }
                 .ArrangeData()
-                .Act(data => data.AsStructType(true).Json)
+                .Act(data => data.AsStructType().Json)
                 .AssertResultIsUnchanged();
 
         [Fact(DisplayName = "Objects that are not supported in Spark throw")]
         public static async Task Case7() =>
             await new { Guid = Guid.NewGuid() }
                 .ArrangeData()
-                .Act(data => data.AsStructType(false))
+                .Act(data => data.AsStructType())
                 .AssertFailsWith(
                     (NotSupportedException e) =>
                         e.Message.Should().Be("System.Guid is not supported in Spark")

--- a/SparkTest.NET.Tests/SparkTest.NET.Tests.csproj
+++ b/SparkTest.NET.Tests/SparkTest.NET.Tests.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BunsenBurner.Verify.Xunit" Version="6.2.1"/>
-        <PackageReference Include="BunsenBurner.Xunit" Version="6.2.1"/>
-        <PackageReference Include="FluentAssertions" Version="6.10.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="BunsenBurner.Verify.Xunit" Version="6.2.1" />
+        <PackageReference Include="BunsenBurner.Xunit" Version="6.2.1" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -24,12 +24,12 @@
     </ItemGroup>
     
     <ItemGroup>
-        <ProjectReference Include="..\SparkTest.NET\SparkTest.NET.csproj"/>
+        <ProjectReference Include="..\SparkTest.NET\SparkTest.NET.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <!-- Example of config for SparkTest.NET-->
-        <AssemblyMetadata Include="SparkTest.NET.ExtraJars" Value="test.jar"/>
-        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"/>
+        <AssemblyMetadata Include="SparkTest.NET.ExtraJars" Value="test.jar" />
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
     </ItemGroup>
 </Project>

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case1.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case1.verified.txt
@@ -1,24 +1,6 @@
-﻿== Parsed Logical Plan ==
-Relation[Id] json
+﻿struct<Id:integer>
 
-== Analyzed Logical Plan ==
-Id: int
-Relation[Id] json
-
-== Optimized Logical Plan ==
-InMemoryRelation [Id], StorageLevel(disk, memory, deserialized, 1 replicas)
-   +- FileScan json [Id] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Id:int>
-
-== Physical Plan ==
-*(1) ColumnarToRow
-+- InMemoryTableScan [Id]
-      +- InMemoryRelation [Id], StorageLevel(disk, memory, deserialized, 1 replicas)
-            +- FileScan json [Id] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Id:int>
-
-== DataFrame Schema ==
-struct<Id:integer>
-
-== DataFrame Data(rows = 20) ==
+(top = 20)
 +---+
 |Id |
 +---+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case1.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case1.verified.txt
@@ -1,0 +1,35 @@
+﻿== Parsed Logical Plan ==
+Relation[Id] json
+
+== Analyzed Logical Plan ==
+Id: int
+Relation[Id] json
+
+== Optimized Logical Plan ==
+InMemoryRelation [Id], StorageLevel(disk, memory, deserialized, 1 replicas)
+   +- FileScan json [Id] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Id:int>
+
+== Physical Plan ==
+*(1) ColumnarToRow
++- InMemoryTableScan [Id]
+      +- InMemoryRelation [Id], StorageLevel(disk, memory, deserialized, 1 replicas)
+            +- FileScan json [Id] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Id:int>
+
+== DataFrame Schema ==
+struct<Id:integer>
+
+== DataFrame Data(rows = 20) ==
++---+
+|Id |
++---+
+|1  |
+|2  |
+|3  |
+|4  |
+|5  |
+|6  |
+|7  |
+|8  |
+|9  |
+|10 |
++---+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case2.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case2.verified.txt
@@ -1,0 +1,26 @@
+﻿== Parsed Logical Plan ==
+Relation[Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] json
+
+== Analyzed Logical Plan ==
+Byte: tinyint, Short: smallint, Int: int, Long: bigint, Float: float, Double: double, Decimal: decimal(10,0), String: string, Char: string, Bool: boolean, Date: date, DateTimeOffset: timestamp, Binary: binary
+Relation[Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] json
+
+== Optimized Logical Plan ==
+InMemoryRelation [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary], StorageLevel(disk, memory, deserialized, 1 replicas)
+   +- FileScan json [Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Byte:tinyint,Short:smallint,Int:int,Long:bigint,Float:float,Double:double,Decimal:decimal(...
+
+== Physical Plan ==
+InMemoryTableScan [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary]
+   +- InMemoryRelation [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary], StorageLevel(disk, memory, deserialized, 1 replicas)
+         +- FileScan json [Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Byte:tinyint,Short:smallint,Int:int,Long:bigint,Float:float,Double:double,Decimal:decimal(...
+
+== DataFrame Schema ==
+struct<Byte:byte,Short:short,Int:integer,Long:long,Float:float,Double:double,Decimal:decimal(10,0),String:string,Char:string,Bool:boolean,Date:date,DateTimeOffset:timestamp,Binary:binary>
+
+== DataFrame Data(rows = 20) ==
++----+-----+---+----+-----+------+-------+------+----+-----+----------+--------------------------+------+
+|Byte|Short|Int|Long|Float|Double|Decimal|String|Char|Bool |Date      |DateTimeOffset            |Binary|
++----+-----+---+----+-----+------+-------+------+----+-----+----------+--------------------------+------+
+|1   |1    |1  |1   |1.0  |1.0   |1      |a     |a   |true |0001-01-01|0001-01-01 00:00:00       |[01]  |
+|2   |2    |2  |2   |2.0  |2.0   |2      |b     |b   |false|9999-12-31|9999-12-31 23:59:59.999999|[01]  |
++----+-----+---+----+-----+------+-------+------+----+-----+----------+--------------------------+------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case2.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case2.verified.txt
@@ -1,23 +1,6 @@
-﻿== Parsed Logical Plan ==
-Relation[Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] json
+﻿struct<Byte:byte,Short:short,Int:integer,Long:long,Float:float,Double:double,Decimal:decimal(10,0),String:string,Char:string,Bool:boolean,Date:date,DateTimeOffset:timestamp,Binary:binary>
 
-== Analyzed Logical Plan ==
-Byte: tinyint, Short: smallint, Int: int, Long: bigint, Float: float, Double: double, Decimal: decimal(10,0), String: string, Char: string, Bool: boolean, Date: date, DateTimeOffset: timestamp, Binary: binary
-Relation[Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] json
-
-== Optimized Logical Plan ==
-InMemoryRelation [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary], StorageLevel(disk, memory, deserialized, 1 replicas)
-   +- FileScan json [Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Byte:tinyint,Short:smallint,Int:int,Long:bigint,Float:float,Double:double,Decimal:decimal(...
-
-== Physical Plan ==
-InMemoryTableScan [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary]
-   +- InMemoryRelation [Byte, Short, Int, LongL, Float, Double, Decimal, String, Char, Bool, Date, DateTimeOffset, Binary], StorageLevel(disk, memory, deserialized, 1 replicas)
-         +- FileScan json [Byte,Short,Int,LongL,Float,Double,Decimal,String,Char,Bool,Date,DateTimeOffset,Binary] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Byte:tinyint,Short:smallint,Int:int,Long:bigint,Float:float,Double:double,Decimal:decimal(...
-
-== DataFrame Schema ==
-struct<Byte:byte,Short:short,Int:integer,Long:long,Float:float,Double:double,Decimal:decimal(10,0),String:string,Char:string,Bool:boolean,Date:date,DateTimeOffset:timestamp,Binary:binary>
-
-== DataFrame Data(rows = 20) ==
+(top = 20)
 +----+-----+---+----+-----+------+-------+------+----+-----+----------+--------------------------+------+
 |Byte|Short|Int|Long|Float|Double|Decimal|String|Char|Bool |Date      |DateTimeOffset            |Binary|
 +----+-----+---+----+-----+------+-------+------+----+-----+----------+--------------------------+------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case3.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case3.verified.txt
@@ -1,0 +1,26 @@
+﻿== Parsed Logical Plan ==
+Relation[Array] json
+
+== Analyzed Logical Plan ==
+Array: array<int>
+Relation[Array] json
+
+== Optimized Logical Plan ==
+InMemoryRelation [Array], StorageLevel(disk, memory, deserialized, 1 replicas)
+   +- FileScan json [Array] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Array:array<int>>
+
+== Physical Plan ==
+InMemoryTableScan [Array]
+   +- InMemoryRelation [Array], StorageLevel(disk, memory, deserialized, 1 replicas)
+         +- FileScan json [Array] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Array:array<int>>
+
+== DataFrame Schema ==
+struct<Array:array<integer>>
+
+== DataFrame Data(rows = 20) ==
++---------+
+|Array    |
++---------+
+|[1, 2, 3]|
+|[4, 5, 6]|
++---------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case3.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case3.verified.txt
@@ -1,23 +1,6 @@
-﻿== Parsed Logical Plan ==
-Relation[Array] json
+﻿struct<Array:array<integer>>
 
-== Analyzed Logical Plan ==
-Array: array<int>
-Relation[Array] json
-
-== Optimized Logical Plan ==
-InMemoryRelation [Array], StorageLevel(disk, memory, deserialized, 1 replicas)
-   +- FileScan json [Array] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Array:array<int>>
-
-== Physical Plan ==
-InMemoryTableScan [Array]
-   +- InMemoryRelation [Array], StorageLevel(disk, memory, deserialized, 1 replicas)
-         +- FileScan json [Array] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Array:array<int>>
-
-== DataFrame Schema ==
-struct<Array:array<integer>>
-
-== DataFrame Data(rows = 20) ==
+(top = 20)
 +---------+
 |Array    |
 +---------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case4.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case4.verified.txt
@@ -1,23 +1,6 @@
-﻿== Parsed Logical Plan ==
-Relation[Map] json
+﻿struct<Map:map<string,integer>>
 
-== Analyzed Logical Plan ==
-Map: map<string,int>
-Relation[Map] json
-
-== Optimized Logical Plan ==
-InMemoryRelation [Map], StorageLevel(disk, memory, deserialized, 1 replicas)
-   +- FileScan json [Map] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Map:map<string,int>>
-
-== Physical Plan ==
-InMemoryTableScan [Map]
-   +- InMemoryRelation [Map], StorageLevel(disk, memory, deserialized, 1 replicas)
-         +- FileScan json [Map] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Map:map<string,int>>
-
-== DataFrame Schema ==
-struct<Map:map<string,integer>>
-
-== DataFrame Data(rows = 20) ==
+(top = 20)
 +------------------------+
 |Map                     |
 +------------------------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case4.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case4.verified.txt
@@ -1,0 +1,26 @@
+﻿== Parsed Logical Plan ==
+Relation[Map] json
+
+== Analyzed Logical Plan ==
+Map: map<string,int>
+Relation[Map] json
+
+== Optimized Logical Plan ==
+InMemoryRelation [Map], StorageLevel(disk, memory, deserialized, 1 replicas)
+   +- FileScan json [Map] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Map:map<string,int>>
+
+== Physical Plan ==
+InMemoryTableScan [Map]
+   +- InMemoryRelation [Map], StorageLevel(disk, memory, deserialized, 1 replicas)
+         +- FileScan json [Map] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<Map:map<string,int>>
+
+== DataFrame Schema ==
+struct<Map:map<string,integer>>
+
+== DataFrame Data(rows = 20) ==
++------------------------+
+|Map                     |
++------------------------+
+|[A -> 1, B -> 2, C -> 3]|
+|[D -> 4, E -> 5, F -> 6]|
++------------------------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case6.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case6.verified.txt
@@ -1,0 +1,26 @@
+﻿== Parsed Logical Plan ==
+Relation[CreatedDate,Person] json
+
+== Analyzed Logical Plan ==
+CreatedDate: timestamp, Person: struct<Name:string,Age:int,Interests:array<struct<Priority:int,Name:string>>>
+Relation[CreatedDate,Person] json
+
+== Optimized Logical Plan ==
+InMemoryRelation [CreatedDate, Person], StorageLevel(disk, memory, deserialized, 1 replicas)
+   +- FileScan json [CreatedDate,Person] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<CreatedDate:timestamp,Person:struct<Name:string,Age:int,Interests:array<struct<Priority:in...
+
+== Physical Plan ==
+InMemoryTableScan [CreatedDate, Person]
+   +- InMemoryRelation [CreatedDate, Person], StorageLevel(disk, memory, deserialized, 1 replicas)
+         +- FileScan json [CreatedDate,Person] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<CreatedDate:timestamp,Person:struct<Name:string,Age:int,Interests:array<struct<Priority:in...
+
+== DataFrame Schema ==
+struct<CreatedDate:timestamp,Person:struct<Name:string,Age:integer,Interests:array<struct<Priority:integer,Name:string>>>>
+
+== DataFrame Data(rows = 20) ==
++-------------------+----------------------------------------+
+|CreatedDate        |Person                                  |
++-------------------+----------------------------------------+
+|0001-01-01 00:00:00|[Billy, 12, [[1, Football], [3, Cars]]] |
+|0001-01-01 00:00:00|[James, 11, [[1, Video Games], [2, TV]]]|
++-------------------+----------------------------------------+

--- a/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case6.verified.txt
+++ b/SparkTest.NET.Tests/__snapshots__/DataFrameExtensionTests.Case6.verified.txt
@@ -1,23 +1,6 @@
-﻿== Parsed Logical Plan ==
-Relation[CreatedDate,Person] json
+﻿struct<CreatedDate:timestamp,Person:struct<Name:string,Age:integer,Interests:array<struct<Priority:integer,Name:string>>>>
 
-== Analyzed Logical Plan ==
-CreatedDate: timestamp, Person: struct<Name:string,Age:int,Interests:array<struct<Priority:int,Name:string>>>
-Relation[CreatedDate,Person] json
-
-== Optimized Logical Plan ==
-InMemoryRelation [CreatedDate, Person], StorageLevel(disk, memory, deserialized, 1 replicas)
-   +- FileScan json [CreatedDate,Person] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<CreatedDate:timestamp,Person:struct<Name:string,Age:int,Interests:array<struct<Priority:in...
-
-== Physical Plan ==
-InMemoryTableScan [CreatedDate, Person]
-   +- InMemoryRelation [CreatedDate, Person], StorageLevel(disk, memory, deserialized, 1 replicas)
-         +- FileScan json [CreatedDate,Person] Batched: false, DataFilters: [], Format: JSON, Location: InMemoryFileIndex[file:/{ProjectDirectory}b..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<CreatedDate:timestamp,Person:struct<Name:string,Age:int,Interests:array<struct<Priority:in...
-
-== DataFrame Schema ==
-struct<CreatedDate:timestamp,Person:struct<Name:string,Age:integer,Interests:array<struct<Priority:integer,Name:string>>>>
-
-== DataFrame Data(rows = 20) ==
+(top = 20)
 +-------------------+----------------------------------------+
 |CreatedDate        |Person                                  |
 +-------------------+----------------------------------------+

--- a/SparkTest.NET/Extensions/DataFrameExtensions.cs
+++ b/SparkTest.NET/Extensions/DataFrameExtensions.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Spark.Interop.Ipc;
 using Microsoft.Spark.Sql;
 using Microsoft.Spark.Sql.Types;
 
@@ -13,93 +19,120 @@ namespace SparkTest.NET.Extensions;
 /// </summary>
 public static class DataFrameExtensions
 {
+    private static bool IsEnumerable(this Type type, out Type? nestedType)
+    {
+        var enumerableInterface = Array.Find(
+            type.GetInterfaces(),
+            x =>
+                x.IsGenericType
+                && typeof(IEnumerable).IsAssignableFrom(x)
+                && x.GenericTypeArguments.Length == 1
+        );
+        if (enumerableInterface == null)
+        {
+            nestedType = null;
+            return false;
+        }
+
+        nestedType = enumerableInterface.GenericTypeArguments[0];
+        return true;
+    }
+
     /// <summary>
     /// Converts a type to its spark type.
     /// </summary>
     /// <param name="type">.NET type</param>
-    /// <param name="serializable">flag to indicate that only types that can be serialized from .NET to Java be supported</param>
     /// <returns>spark data type</returns>
-    /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
-    public static DataType AsSparkType(this Type type, bool serializable)
+    /// <exception cref="NotSupportedException">if the type is not supported in spark</exception>
+    [SuppressMessage("Design", "MA0051:Method is too long")]
+    public static DataType AsSparkType(this Type type)
     {
         while (true)
         {
-            if (type.IsGenericType && type.Namespace != null)
-            {
-                type = type.GenericTypeArguments[0];
-                continue;
-            }
-
-            // all supported types that can be serialized from dotnet to java
-            if (type == typeof(bool))
+            if (typeof(bool).IsAssignableFrom(type))
                 return new BooleanType();
-            if (type == typeof(int))
+            if (typeof(byte).IsAssignableFrom(type))
+                return new ByteType();
+            if (typeof(short).IsAssignableFrom(type))
+                return new ShortType();
+            if (typeof(int).IsAssignableFrom(type))
                 return new IntegerType();
-            if (type == typeof(long))
+            if (typeof(long).IsAssignableFrom(type))
                 return new LongType();
-            if (type == typeof(double))
+            if (typeof(float).IsAssignableFrom(type))
+                return new FloatType();
+            if (typeof(double).IsAssignableFrom(type))
                 return new DoubleType();
-            if (type == typeof(Date))
+            if (typeof(decimal).IsAssignableFrom(type))
+                return new DecimalType();
+            if (typeof(Date).IsAssignableFrom(type) || typeof(DateTime).IsAssignableFrom(type))
                 return new DateType();
-            if (type == typeof(Timestamp))
-                return new TimestampType();
-            if (type == typeof(string))
-                return new StringType();
-
-            if (serializable)
+            if (
+                typeof(Timestamp).IsAssignableFrom(type)
+                || typeof(DateTimeOffset).IsAssignableFrom(type)
+            )
             {
-                throw new NotSupportedException(
-                    $"{type.FullName} is not supported in Spark or cannot be serialized from .NET to Java at this time"
-                );
+                return new TimestampType();
             }
 
-            if (type == typeof(byte))
-                return new ByteType();
-            if (type == typeof(short))
-                return new ShortType();
-            if (type == typeof(decimal))
-                return new DecimalType();
-            if (type == typeof(float))
-                return new FloatType();
-            if (type.IsClass)
-                return type.AsStructType(serializable);
+            if (typeof(string).IsAssignableFrom(type) || typeof(char).IsAssignableFrom(type))
+                return new StringType();
+            if (typeof(byte[]).IsAssignableFrom(type))
+                return new BinaryType();
+            if (
+                type.IsEnumerable(out var ct1)
+                && ct1 is { IsGenericType: true }
+                && typeof(KeyValuePair<,>).IsAssignableFrom(ct1.GetGenericTypeDefinition())
+                && ct1.GenericTypeArguments.Length > 1
+            )
+            {
+                var keyType = ct1.GenericTypeArguments[0].AsSparkType();
+                var valueType = ct1.GenericTypeArguments[1].AsSparkType();
+                return new MapType(keyType, valueType);
+            }
 
-            throw new NotSupportedException($"{type.FullName} is not supported in Spark");
+            if (type.IsEnumerable(out var ct2) && ct2 != null)
+            {
+                var innerType = ct2.AsSparkType();
+                return new ArrayType(innerType);
+            }
+
+            if (type.IsClass)
+                return type.AsStructType();
+            if (type is not { IsGenericType: true, Namespace: not null })
+                throw new NotSupportedException($"{type.FullName} is not supported in Spark");
+
+            type = type.GenericTypeArguments[0];
         }
     }
 
     /// <summary>
     /// Creates a struct type from a given T
     /// </summary>
-    /// <param name="serializable">flag to indicate that all fields of the struct must be serializable from .NET to Java</param>
     /// <typeparam name="T">some T</typeparam>
     /// <returns>struct type</returns>
     /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
     [Pure]
-    public static StructType CreateStructType<T>(bool serializable) where T : class =>
-        typeof(T).AsStructType(serializable);
+    public static StructType CreateStructType<T>() where T : class => typeof(T).AsStructType();
 
     /// <summary>
     /// Creates a struct type from a given T
     /// </summary>
     /// <param name="_">instance of T</param>
-    /// <param name="serializable">flag to indicate that all fields of the struct must be serializable from .NET to Java</param>
     /// <typeparam name="T">some T</typeparam>
     /// <returns>struct type</returns>
     /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
     [Pure]
-    public static StructType AsStructType<T>(this T _, bool serializable) where T : class =>
-        CreateStructType<T>(serializable);
+    public static StructType AsStructType<T>(this T _) where T : class => CreateStructType<T>();
 
     /// <summary>
     /// Creates a struct type from a given Type
     /// </summary>
     /// <param name="type">type to convert</param>
-    /// <param name="serializable">flag to indicate that all fields of the struct must be serializable from .NET to Java</param>
     /// <returns>struct type</returns>
-    /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
+    /// <exception cref="NotSupportedException">if the type is not supported in spark</exception>
     [Pure]
-    public static StructType AsStructType(this Type type, bool serializable) =>
+    public static StructType AsStructType(this Type type) =>
         new(
             type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Select(
@@ -107,51 +140,17 @@ public static class DataFrameExtensions
                         x.PropertyType.IsGenericType
                             ? new StructField(
                                 x.Name,
-                                x.PropertyType.AsSparkType(serializable),
+                                x.PropertyType.AsSparkType(),
                                 Nullable.GetUnderlyingType(x.PropertyType.GenericTypeArguments[0])
                                     == null
                             )
                             : new StructField(
                                 x.Name,
-                                x.PropertyType.AsSparkType(serializable),
+                                x.PropertyType.AsSparkType(),
                                 Nullable.GetUnderlyingType(x.PropertyType) == null
                             )
                 )
         );
-
-    /// <summary>
-    /// Creates a data frame from a given TData
-    /// </summary>
-    /// <param name="session">session</param>
-    /// <param name="first">first data item</param>
-    /// <param name="rest">other data items</param>
-    /// <typeparam name="TData">some TData reference type</typeparam>
-    /// <returns>dataframe</returns>
-    /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
-    [Pure]
-    public static DataFrame CreateDataFrameFromData<TData>(
-        this SparkSession session,
-        TData first,
-        params TData[] rest
-    ) where TData : class
-    {
-        var schema = CreateStructType<TData>(true);
-        return session.CreateDataFrame(
-            new List<TData> { first }
-                .Concat(rest)
-                .Select(
-                    data =>
-                        new GenericRow(
-                            first
-                                .GetType()
-                                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                                .Select(p => p.GetValue(data))
-                                .ToArray()
-                        )
-                ),
-            schema
-        );
-    }
 
     /// <summary>
     /// Creates an empty data frame
@@ -164,4 +163,162 @@ public static class DataFrameExtensions
             new[] { new GenericRow(Array.Empty<object>()) },
             new StructType(Enumerable.Empty<StructField>())
         );
+
+    /// <summary>
+    /// Creates a data frame from a given TData loaded into spark as a JSON file
+    /// </summary>
+    /// <param name="session">session</param>
+    /// <param name="first">first data item</param>
+    /// <param name="rest">other data items</param>
+    /// <typeparam name="TData">some TData reference type</typeparam>
+    /// <returns>dataframe</returns>
+    /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
+    [Pure]
+    public static DataFrame CreateDataFrameFromData<TData>(
+        this SparkSession session,
+        TData first,
+        params TData[] rest
+    ) where TData : class => session.CreateDataFrameFromData(rest.Prepend(first));
+
+    /// <summary>
+    /// Creates a data frame from a given TData loaded into spark as a JSON file
+    /// </summary>
+    /// <param name="session">session</param>
+    /// <param name="data">data</param>
+    /// <typeparam name="TData">some TData reference type</typeparam>
+    /// <returns>dataframe</returns>
+    /// <exception cref="NotSupportedException">if the type is not supported in spark, or not serializable but supported in Spark</exception>
+    /// <exception cref="InvalidOperationException">if the enumerable is empty</exception>
+    [Pure]
+    public static DataFrame CreateDataFrameFromData<TData>(
+        this SparkSession session,
+        IEnumerable<TData> data
+    ) where TData : class
+    {
+        var lst = data.ToArray();
+        if (lst.Length == 0)
+            throw new InvalidOperationException("Enumerable must not be empty");
+
+        var schema = CreateStructType<TData>();
+
+        // write data to a temp file
+        var fn = Guid.NewGuid().ToString();
+        var pwd = Directory.GetCurrentDirectory();
+        var filePath = Path.Combine(pwd, fn);
+
+        using (var fileStream = File.Create(filePath))
+        {
+            using (var utf8JsonWriter = new Utf8JsonWriter(fileStream))
+                JsonSerializer.Serialize(utf8JsonWriter, lst);
+        }
+
+        // load file into spark and cache and force execution
+        var df = session.Read().Schema(schema).Json(filePath).Cache();
+        _ = df.Collect().ToArray();
+
+        // remove file
+        File.Delete(filePath);
+        return df;
+    }
+
+    /// <summary>
+    /// Displays rows of the `DataFrame` in tabular form
+    /// </summary>
+    /// <param name="dataFrame">data frame</param>
+    /// <param name="numRows">number of rows to show</param>
+    /// <param name="truncate">
+    /// if set to more than 0, truncates strings to `truncate`
+    /// characters and all cells will be aligned right
+    /// </param>
+    /// <param name="vertical">
+    /// If set to true, prints output rows vertically
+    /// (one line per column value)
+    /// </param>
+    /// <returns>row data</returns>
+    public static string ShowString(
+        this DataFrame dataFrame,
+        int numRows = 20,
+        int truncate = 20,
+        bool vertical = false
+    ) => (string)dataFrame.Reference.Invoke("showString", numRows, truncate, vertical);
+
+    /// <summary>
+    /// Replaces the non-deterministic parts of an explain plan result
+    /// </summary>
+    /// <param name="result">result of calling explain</param>
+    /// <param name="removeIndexes">flag to indicate that indexes should be removed, not re-indexed</param>
+    /// <returns>re-indexed explain plan</returns>
+    private static string ReIndexExplainPlan(this string result, bool removeIndexes)
+    {
+        // strip out all the # index values that increment over the life of a spark session
+        var indexes = result
+            .Split('#')
+            .Select(part =>
+            {
+                var newIndex = new string(part.TakeWhile(char.IsDigit).ToArray());
+                return newIndex.Length > 0 ? $"#{newIndex}" : null;
+            })
+            .OfType<string>()
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(_ => _, StringComparer.Ordinal)
+            .Select((index, i) => (Current: index, Replacement: $"#{i + 1}"))
+            .OrderByDescending(_ => _);
+
+        // replace them with stable indexes that are scope to the current plan
+        return indexes.Aggregate(
+            result,
+            (s, pair) =>
+            {
+                var target = $"({pair.Current})([^0-9]|$)";
+                var replace = $"{(!removeIndexes ? pair.Replacement : string.Empty)}$2";
+                return Regex.Replace(
+                    s,
+                    target,
+                    replace,
+                    RegexOptions.None,
+                    TimeSpan.FromMilliseconds(100)
+                );
+            }
+        );
+    }
+
+    /// <summary>
+    /// Returns the plans (logical and physical) with a format specified by a given explain mode
+    /// </summary>
+    /// <param name="dataFrame">data frame</param>
+    /// <param name="mode">Specifies the expected output format of plans</param>
+    /// <returns>plan</returns>
+    public static string ExplainString(this DataFrame dataFrame, string mode = "extended") =>
+        (string)
+            ((JvmObjectReference)dataFrame.Reference.Invoke("queryExecution")).Invoke(
+                "explainString",
+                (JvmObjectReference)
+                    dataFrame.Reference.Jvm.CallStaticJavaMethod(
+                        "org.apache.spark.sql.execution.ExplainMode",
+                        "fromString",
+                        mode
+                    )
+            );
+
+    /// <summary>
+    /// Debugs a provided data frame, including plan, schema and data
+    /// </summary>
+    /// <param name="dataFrame">data frame</param>
+    /// <param name="numRows">number of rows to show</param>
+    /// <param name="truncate">
+    /// if set to more than 0, truncates strings to `truncate`
+    /// characters and all cells will be aligned right
+    /// </param>
+    /// <param name="vertical">
+    /// If set to true, prints output rows vertically
+    /// (one line per column value)
+    /// </param>
+    /// <returns>data frame debug details</returns>
+    public static string Debug(
+        this DataFrame dataFrame,
+        int numRows = 20,
+        int truncate = 0,
+        bool vertical = false
+    ) =>
+        $"{dataFrame.ExplainString().ReIndexExplainPlan(removeIndexes: true)}\n== DataFrame Schema ==\n{dataFrame.Schema().SimpleString}\n\n== DataFrame Data(rows = {numRows}) ==\n{dataFrame.ShowString(numRows, truncate, vertical)}";
 }

--- a/SparkTest.NET/SparkTest.NET.csproj
+++ b/SparkTest.NET/SparkTest.NET.csproj
@@ -64,6 +64,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Spark" Version="2.1.1" />
+        <PackageReference Include="System.Text.Json" Version="7.0.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This opens up the C# types that can be used to create data frames. It uses JSON files and cache to overcome the serialization limitations in Spark.NET